### PR TITLE
chore: update PHP and Laravel version support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
   "keywords": ["php", "fias", "laravel"],
   "license": "MIT",
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.2 <=8.4",
     "liquetsoft/fias-component": "^14.0",
-    "illuminate/database": "^9.0|^10.0|^11.0",
-    "illuminate/http": "^9.0|^10.0|^11.0",
-    "laravel/framework": "^9.0|^10.0|^11.0"
+    "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/http": "^9.0|^10.0|^11.0|^12.0",
+    "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
- Updated PHP version support to >=8.2 <=8.4
- Added Laravel ^12.0 support for illuminate/database, illuminate/http, and laravel/framework