### PR TITLE
Update PHP and Laravel version support to include PHP 8.4 and Laravel 12

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['8.2', '8.3']
-        laravel-versions: ['^9.0', '^10.0', '^11.0']
+        php-versions: ['8.2', '8.3', '8.4']
+        laravel-versions: ['^9.0', '^10.0', '^11.0', '^12.0']
     steps:
     - uses: actions/checkout@v2
     - name: Install PHP
@@ -70,8 +70,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3']
-        laravel-version: ['^9.0', '^10.0', '^11.0']
+        php-version: ['8.2', '8.3', '8.4']
+        laravel-version: ['^9.0', '^10.0', '^11.0', '^12.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
   "keywords": ["php", "fias", "laravel"],
   "license": "MIT",
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.2 <=8.4",
     "liquetsoft/fias-component": "^14.0",
-    "illuminate/database": "^9.0|^10.0|^11.0",
-    "illuminate/http": "^9.0|^10.0|^11.0",
-    "laravel/framework": "^9.0|^10.0|^11.0"
+    "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/http": "^9.0|^10.0|^11.0|^12.0",
+    "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
This PR updates the project to support the latest versions of PHP and Laravel. The changes include:

### Changes in `composer.json`
- Added support for PHP 8.4 (`>=8.2 <=8.4`).
- Added support for Laravel 12 (`^12.0`) for `illuminate/database`, `illuminate/http`, and `laravel/framework`.

### Changes in GitHub Actions Workflow
- Added PHP 8.4 to the testing matrix.
- Added Laravel 12 to the testing matrix.
- Ensured compatibility with the new versions in the build and Laravel installation steps.

### Why is this important?
- Keeps the project up-to-date with the latest PHP and Laravel releases.
- Ensures compatibility for users who are already using or planning to upgrade to PHP 8.4 or Laravel 12.
- Maintains the project's reliability and relevance in the ecosystem.

### Testing
The updated workflow will automatically test the changes against all supported PHP and Laravel versions, including the newly added ones.

---

This PR is ready for review and merging. Let me know if any additional changes are needed! 🚀